### PR TITLE
Fix exception that occurs when designer is loaded in VS2013

### DIFF
--- a/OneBusAway.WP7.ViewModel/AViewModel.cs
+++ b/OneBusAway.WP7.ViewModel/AViewModel.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 using System;
+using System.IO.IsolatedStorage;
 using System.Net;
 using System.Windows;
 using System.Windows.Controls;
@@ -61,10 +62,13 @@ namespace OneBusAway.WP7.ViewModel
             this.lazyBusServiceModel = busServiceModel;
             this.lazyAppDataModel = appDataModel;
 
-            locationTracker = new LocationTracker();
-            operationTracker = new AsyncOperationTracker();
+	        if (!IsInDesignMode)
+	        {
+		        locationTracker = new LocationTracker();
+		        operationTracker = new AsyncOperationTracker();
+	        }
 
-            // Set up the default action, just execute in the same thread
+	        // Set up the default action, just execute in the same thread
             UIAction = (uiAction => uiAction());
             
             eventsRegistered = false;
@@ -127,6 +131,14 @@ namespace OneBusAway.WP7.ViewModel
                 return lazyLocationModel;
             }
         }
+
+		protected bool IsInDesignMode
+		{
+			get
+			{
+				return IsInDesignModeStatic;
+			}
+		}
   
         /// <summary>
         /// Subclasses should queue and dequeue their async calls onto this object to tie into the Loading property.
@@ -196,6 +208,33 @@ namespace OneBusAway.WP7.ViewModel
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
+
+		private static bool? isInDesignModeStatic = null;
+		public static bool IsInDesignModeStatic // Convenient method that can be accessed out of an inherited class
+		{
+			get
+			{
+				if (isInDesignModeStatic.HasValue)
+				{
+					// only do the check once and use the last value forever
+					return isInDesignModeStatic.Value;
+				}
+				try
+				{
+					var isoStor = IsolatedStorageSettings.ApplicationSettings.Contains("asasdasd");
+					isInDesignModeStatic = false;
+					return isInDesignModeStatic.Value;
+				}
+				catch (Exception ex)
+				{
+					// Toss out any errors we get
+				}
+				// If we get here that means we got an error
+				isInDesignModeStatic = true;
+				return isInDesignModeStatic.Value;
+			}
+		}
+
 
         /// <summary>
         /// Registers all event handlers with the model.  Call this when 

--- a/OneBusAway/AboutPage.xaml
+++ b/OneBusAway/AboutPage.xaml
@@ -76,7 +76,8 @@
             <TextBlock 
                 Foreground="{StaticResource OBAForegroundBrush}" 
                 HorizontalAlignment="Center" 
-                Text="http://onebusawaywp7.codeplex.com" 
+                Text="https://github.com/OneBusAway/onebusaway-windows-phone" 
+				FontSize="15.5"
                 MouseLeftButtonUp="TextBlock_MouseLeftButtonUp" 
                 Margin="10"
                 />


### PR DESCRIPTION
Detects design mode and does not instantiate a LocationService in that case. Used a trick where isolated storage throws an exception when you try to access it from Design mode (on the other hand, isolated storage is available when the app is running on the phone or emulator).
