### PR TITLE
Optimized boot time loading perf

### DIFF
--- a/OneBusAway.WP7.ViewModel/LocationTracker.cs
+++ b/OneBusAway.WP7.ViewModel/LocationTracker.cs
@@ -30,6 +30,7 @@ namespace OneBusAway.WP7.ViewModel
         private static GeoCoordinateWatcher locationWatcher;
 
         public static GeoCoordinate LastKnownLocation { get; set; }
+
         public static GeoPositionStatus LocationStatus
         {
             get
@@ -46,7 +47,7 @@ namespace OneBusAway.WP7.ViewModel
             LastKnownLocation = null;
 
             locationWatcher = new GeoCoordinateWatcher(GeoPositionAccuracy.High);
-            locationWatcher.MovementThreshold = 5; // 5 meters
+            locationWatcher.MovementThreshold = 20; // 20 meters
             locationWatcher.PositionChanged += new EventHandler<GeoPositionChangedEventArgs<GeoCoordinate>>(LocationWatcher_PositionChanged);
             locationWatcher.StatusChanged += new EventHandler<GeoPositionStatusChangedEventArgs>(locationWatcher_StatusChanged);
 
@@ -55,6 +56,7 @@ namespace OneBusAway.WP7.ViewModel
                 || (bool)IsolatedStorageSettings.ApplicationSettings["UseLocation"] == true)
             {
                 locationWatcher.Start();
+                LastKnownLocation = locationWatcher.Position.Location;
             }
         }
 
@@ -68,15 +70,10 @@ namespace OneBusAway.WP7.ViewModel
 
         private static void LocationWatcher_PositionChanged(object sender, GeoPositionChangedEventArgs<GeoCoordinate> e)
         {
-            // The location service will return the last known location of the phone when it first starts up.  Since
-            // we can't refresh the home screen wait until a recent location value is found before using it.  The
-            // location must be less than 5 minute old.
+            // The location service will return the last known location of the phone when it first starts up.
             if (e.Position.Location.IsUnknown == false)
             {
-                if ((DateTime.Now - e.Position.Timestamp.DateTime) < new TimeSpan(0, 5, 0))
-                {
-                    LastKnownLocation = e.Position.Location;
-                }
+                LastKnownLocation = e.Position.Location;
             }
 
             if (PositionChanged != null)

--- a/OneBusAway.WP7.ViewModel/MainPageVM.cs
+++ b/OneBusAway.WP7.ViewModel/MainPageVM.cs
@@ -111,6 +111,22 @@ namespace OneBusAway.WP7.ViewModel
         #endregion
 
         #region Public Methods
+        
+
+        public void RegisterOnCombinedUpdatedCallback(Action<IList<Route>, IList<Stop>> callback)
+        {
+            busServiceModel.CombinedInfoForLocation_Completed += (sender, args) => callback(args.routes, args.stops);
+        }
+
+        public void RegisterOnRoutesUpdatedCallback(Action<IList<Route>> callback)
+        {
+            busServiceModel.RoutesForLocation_Completed += (sender, args) => callback(args.routes);
+        }
+
+        public void RegisterOnStopsUpdatedCallback(Action<List<Stop>> callback)
+        {
+            busServiceModel.StopsForLocation_Completed += (sender, args) => callback(args.stops);
+        }
 
         public void LoadInfoForLocation()
         {

--- a/OneBusAway.WP7.ViewModel/MainPageVM.cs
+++ b/OneBusAway.WP7.ViewModel/MainPageVM.cs
@@ -68,6 +68,8 @@ namespace OneBusAway.WP7.ViewModel
 
         #region Public Properties
 
+        public bool InfoForLocationLoaded = false;
+
         private ObservableCollection<Stop> stopsForLocation;
         public ObservableCollection<Stop> StopsForLocation 
         {
@@ -133,6 +135,8 @@ namespace OneBusAway.WP7.ViewModel
             {
                 busServiceModel.CombinedInfoForLocation(location, defaultSearchRadius, -1, invalidateCache);
             });
+
+            InfoForLocationLoaded = true;
         }
 
         public void LoadFavorites()

--- a/OneBusAway/MainPage.xaml.cs
+++ b/OneBusAway/MainPage.xaml.cs
@@ -15,14 +15,18 @@
 using System;
 using System.Collections.Generic;
 using System.Device.Location;
+using System.Linq;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Navigation;
+using Windows.Phone.Speech.VoiceCommands;
 using Microsoft.Phone.Controls;
 using Microsoft.Phone.Controls.Maps;
 using Microsoft.Phone.Controls.Maps.Core;
@@ -186,9 +190,67 @@ namespace OneBusAway.WP7.View
         {
             base.OnNavigatedTo(e);
 
+            if (e.NavigationMode == NavigationMode.New)
+            {
+                // First, we'll look for the special "voiceCommandName" key in the QueryString arguments. If it's
+                // present, the application was activated with Voice Commands, and we'll take action based on the name
+                // of the command that was triggered.
+                string voiceCommandName;
+
+                if (NavigationContext.QueryString.TryGetValue("voiceCommandName", out voiceCommandName))
+                {
+                    HandleVoiceCommand(voiceCommandName);
+                }
+                else
+                {
+                    // If we just freshly launched this app without a Voice Command, asynchronously try to install the 
+                    // Voice Commands.
+                    // If the commands are already installed, no action will be taken--there's no need to check.
+                    Task.Run(() => InstallVoiceCommands());
+                }
+            }
+            else
+            {
+                // If we're returning to the page (e.g. from suspending in the middle of anything), restore our state
+                // back to acceptance of input.
+                //SetSearchState(SearchState.ReadyForInput);
+            }
+
             viewModel.RegisterEventHandlers(Dispatcher);
 
             navigatedAway = false;
+        }
+
+        private void HandleVoiceCommand(string voiceCommandName)
+        {
+            switch (voiceCommandName)
+            {
+                case "favorites":
+                    PC.SelectedIndex = (int)MainPagePivots.Favorites;
+                    PhoneApplicationService.Current.State["MainPageSelectedPivot"] = MainPagePivots.Favorites;
+                    break;
+                case "routes":
+                    PC.SelectedIndex = (int)MainPagePivots.Routes;
+                    PhoneApplicationService.Current.State["MainPageSelectedPivot"] = MainPagePivots.Routes;
+
+                    if (NavigationContext.QueryString.ContainsKey("route"))
+                        ProcessSearch(NavigationContext.QueryString["route"]);
+
+                    break;
+                case "stops":
+                    PC.SelectedIndex = (int)MainPagePivots.Stops;
+                    PhoneApplicationService.Current.State["MainPageSelectedPivot"] = MainPagePivots.Stops;
+                    break;
+                case "recent":
+                    PC.SelectedIndex = (int)MainPagePivots.Recents;
+                    PhoneApplicationService.Current.State["MainPageSelectedPivot"] = MainPagePivots.Recents;
+                    break;
+                case "NaturalLanguage":
+                    ProcessSearch(NavigationContext.QueryString["naturalLanguage"]);
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
         }
 
         protected override void OnNavigatedFrom(System.Windows.Navigation.NavigationEventArgs e)
@@ -300,6 +362,52 @@ namespace OneBusAway.WP7.View
                     Navigate(new Uri("/StopsMapPage.xaml", UriKind.Relative));
                 });
             }
+        }
+
+        /// <summary>
+        /// Installs the Voice Command Definition (VCD) file associated with the application.
+        /// Based on OS version, installs a separate document based on version 1.0 of the schema or version 1.1.
+        /// </summary>
+        private async void InstallVoiceCommands()
+        {
+            const string wp80VcdPath = "ms-appx:///VoiceCommandDefinition_8.0.xml";
+            const string wp81VcdPath = "ms-appx:///VoiceCommandDefinition_8.1.xml";
+
+            //try
+            //{
+            bool using81OrAbove = ((Environment.OSVersion.Version.Major >= 8)
+                && (Environment.OSVersion.Version.Minor >= 10));
+
+            bool using8OrAbove = (Environment.OSVersion.Version.Major >= 8);
+
+            var vcdUri = new Uri(using81OrAbove ? wp81VcdPath : wp80VcdPath);
+
+            if (using8OrAbove)
+            {
+                await VoiceCommandService.InstallCommandSetsFromFileAsync(vcdUri);
+
+                viewModel.RegisterOnCombinedUpdatedCallback((routes, stops) =>
+                {
+                    if (VoiceCommandService.InstalledCommandSets.ContainsKey("englishCommands"))
+                    {
+                        VoiceCommandService.InstalledCommandSets["englishCommands"].UpdatePhraseListAsync("route",
+                            routes.Select(r => r.shortName));
+                        VoiceCommandService.InstalledCommandSets["englishCommands"].UpdatePhraseListAsync("stop",
+                            stops.Select(s => s.name));
+                    }
+                });
+            }
+
+            //VoiceCommandService.InstalledCommandSets.Values.First().UpdatePhraseListAsync()
+            //}
+            //catch (Exception vcdEx)
+            //{
+            //    Dispatcher.BeginInvoke(() =>
+            //    {
+            //        //MessageBox.Show(String.Format(
+            //        //    AppResources.VoiceCommandInstallErrorTemplate, vcdEx.HResult, vcdEx.Message));
+            //    });
+            //}
         }
 
         #endregion

--- a/OneBusAway/OneBusAway.WP7.View.csproj
+++ b/OneBusAway/OneBusAway.WP7.View.csproj
@@ -307,6 +307,8 @@
     <Content Include="Images\CenterIcon.png" />
     <Content Include="SplashImage.png" />
     <Content Include="SplashScreenImage.jpg" />
+    <Content Include="VoiceCommandDefinition_8.0.xml" />
+    <Content Include="VoiceCommandDefinition_8.1.xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OneBusAway.WP7.Model\OneBusAway.WP7.Model.csproj">

--- a/OneBusAway/Properties/WMAppManifest.xml
+++ b/OneBusAway/Properties/WMAppManifest.xml
@@ -15,6 +15,7 @@
       <Capability Name="ID_CAP_MEDIALIB_AUDIO" />
       <Capability Name="ID_CAP_MEDIALIB_PHOTO" />
       <Capability Name="ID_CAP_MEDIALIB_PLAYBACK" />
+      <Capability Name="ID_CAP_SPEECH_RECOGNITION" />
     </Capabilities>
     <Tasks>
       <DefaultTask Name="_default" NavigationPage="MainPage.xaml" />

--- a/OneBusAway/VoiceCommandDefinition_8.0.xml
+++ b/OneBusAway/VoiceCommandDefinition_8.0.xml
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<VoiceCommands xmlns="http://schemas.microsoft.com/voicecommands/1.0">
+    <!-- The CommandSet Name is used to programmatically access the CommandSet -->
+    <CommandSet xml:lang="en-us" Name="englishCommands">
+        <!-- The CommandPrefix provides an alternative to your full app name for invocation -->
+        <CommandPrefix> MSDN </CommandPrefix>
+        <!-- The CommandSet Example appears in the global help alongside your app name -->
+        <Example> search </Example>
+
+        <Command Name="MSDNSearch">
+            <!-- The Command example appears in the drill-down help page for your app -->
+            <Example> do a search </Example>
+
+            <!-- ListenFor elements provide ways to say the command, including references to 
+            {PhraseLists} and {PhraseTopics} as well as [optional] words -->
+            <ListenFor> [do a] Search [for] {*} </ListenFor>
+            <ListenFor> Find {*} </ListenFor>
+            <ListenFor> Look [for] {*} </ListenFor>
+
+            <!--Feedback provides the displayed and spoken text when your command is triggered -->
+            <Feedback> Searching MSDN... </Feedback>
+
+            <!-- Navigate specifies the desired page or invocation destination for the Command-->
+            <Navigate Target="MainPage.xaml" />
+        </Command>
+    </CommandSet>
+</VoiceCommands>

--- a/OneBusAway/VoiceCommandDefinition_8.1.xml
+++ b/OneBusAway/VoiceCommandDefinition_8.1.xml
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Be sure to use the new v1.1 namespace to utilize the new PhraseTopic feature -->
+<VoiceCommands xmlns="http://schemas.microsoft.com/voicecommands/1.1">
+    <!-- The CommandSet Name is used to programmatically access the CommandSet -->
+    <CommandSet xml:lang="en-us" Name="englishCommands">
+        <!-- The CommandPrefix provides an alternative to your full app name for invocation -->
+        <CommandPrefix>One Bus Away</CommandPrefix>
+        <!-- The CommandSet Example appears in the global help alongside your app name -->
+        <Example> routes near me </Example>
+
+        <Command Name="favorites">
+            <!-- The Command example appears in the drill-down help page for your app -->
+            <Example> show my favorites </Example>
+
+            <!-- ListenFor elements provide ways to say the command, including references to 
+            {PhraseLists} and {PhraseTopics} as well as [optional] words -->
+            <ListenFor> favorities </ListenFor>
+            <ListenFor> favorite </ListenFor>
+            <ListenFor> show my favorites </ListenFor>
+
+          <!--Feedback provides the displayed and spoken text when your command is triggered -->
+            <Feedback> Opening your favorites... </Feedback>
+
+            <!-- Navigate specifies the desired page or invocation destination for the Command-->
+            <Navigate Target="MainPage.xaml" />
+        </Command>
+
+        <Command Name="recent">
+            <!-- The Command example appears in the drill-down help page for your app -->
+            <Example> show recent </Example>
+
+            <!-- ListenFor elements provide ways to say the command, including references to 
+            {PhraseLists} and {PhraseTopics} as well as [optional] words -->
+            <ListenFor> recent </ListenFor>
+            <ListenFor> show recent </ListenFor>
+
+          <!--Feedback provides the displayed and spoken text when your command is triggered -->
+            <Feedback> Opening recent... </Feedback>
+
+            <!-- Navigate specifies the desired page or invocation destination for the Command-->
+            <Navigate Target="MainPage.xaml" />
+        </Command>
+
+        <Command Name="routes">
+            <!-- The Command example appears in the drill-down help page for your app -->
+            <Example> show routes near me </Example>
+
+            <!-- ListenFor elements provide ways to say the command, including references to 
+            {PhraseLists} and {PhraseTopics} as well as [optional] words -->
+            <ListenFor> [show] routes near me </ListenFor>
+            <ListenFor> when is the next {route} [bus] </ListenFor>
+            <ListenFor> when's the next {route} [bus] </ListenFor>
+            <ListenFor> show me route {route} </ListenFor>
+            <ListenFor> route {route} </ListenFor>
+            <ListenFor> {route} </ListenFor>
+
+          <!--Feedback provides the displayed and spoken text when your command is triggered -->
+            <Feedback> Opening routes... </Feedback>
+
+            <!-- Navigate specifies the desired page or invocation destination for the Command-->
+            <Navigate Target="MainPage.xaml" />
+        </Command>
+
+        <Command Name="stops">
+            <!-- The Command example appears in the drill-down help page for your app -->
+            <Example> show stops near me </Example>
+
+            <!-- ListenFor elements provide ways to say the command, including references to 
+            {PhraseLists} and {PhraseTopics} as well as [optional] words -->
+            <ListenFor> [show] stops </ListenFor>
+            <ListenFor> [show] stops near me </ListenFor>
+            <ListenFor> [show] stops nearby </ListenFor>
+            <ListenFor> stop {stop} </ListenFor>
+
+          <!--Feedback provides the displayed and spoken text when your command is triggered -->
+            <Feedback> Opening stop... </Feedback>
+
+            <!-- Navigate specifies the desired page or invocation destination for the Command-->
+            <Navigate Target="MainPage.xaml" />
+        </Command>
+
+        <Command Name="NaturalLanguage">
+            <Example> When is the next 545? </Example>
+            <ListenFor> when is the next {naturalLanguage} </ListenFor>
+            <ListenFor> when's the next {naturalLanguage} </ListenFor>
+            <ListenFor> find {naturalLanguage} </ListenFor>
+            <ListenFor> {naturalLanguage} </ListenFor>
+            <Feedback> Taking the bus, is your car broken? ... </Feedback>
+            <Navigate Target="MainPage.xaml" />
+        </Command>
+
+        <PhraseList Label="route">
+            <Item>545</Item>
+            <Item>545 redmond</Item>
+        </PhraseList>
+
+        <PhraseList Label="stop">
+        </PhraseList>
+
+        <PhraseTopic Label="naturalLanguage" Scenario="Natural Language">
+            <Subject> Bus stops </Subject>
+        </PhraseTopic>
+
+    </CommandSet>
+</VoiceCommands>


### PR DESCRIPTION
I moved the bus and stop info loading from boot time to the PC_SelectionChanged event if the first pivot selected is Favorites or Recent. The last known location is set at boot time directly to be able to access Favorites and Recent data right away instead of having to wait for the location and routes data to load.
