### PR TITLE
Change the RouteDetails.RefreshArrivalsForStops to use Safe Location

### DIFF
--- a/OneBusAway.WP7.Model/AppDataModel.cs
+++ b/OneBusAway.WP7.Model/AppDataModel.cs
@@ -48,7 +48,6 @@ namespace OneBusAway.WP7.Model
         #region Events
 
         public event EventHandler<FavoritesChangedEventArgs> Favorites_Changed;
-        public event EventHandler<FavoritesChangedEventArgs> Recents_Changed;
 
         #endregion
 

--- a/OneBusAway.WP7.Test/AppDataModelTests.cs
+++ b/OneBusAway.WP7.Test/AppDataModelTests.cs
@@ -39,8 +39,6 @@ namespace OneBusAway.WP7.Test
         private FakeData fakeData = null;
         private Dictionary<FavoriteType, string> fileNames;
 
-        private FavoriteRouteAndStop fakeFavorite;
-
         public AppDataModelTests()
         {
             appDataModel = AppDataModel.Singleton;

--- a/OneBusAway.WP7.ViewModel/AViewModel.cs
+++ b/OneBusAway.WP7.ViewModel/AViewModel.cs
@@ -245,7 +245,7 @@ namespace OneBusAway.WP7.ViewModel
 					isInDesignModeStatic = false;
 					return isInDesignModeStatic.Value;
 				}
-				catch (Exception ex)
+				catch (Exception)
 				{
 					// Toss out any errors we get
 				}

--- a/OneBusAway.WP7.ViewModel/IAppDataModel.cs
+++ b/OneBusAway.WP7.ViewModel/IAppDataModel.cs
@@ -38,9 +38,7 @@ namespace OneBusAway.WP7.ViewModel
     {
 
         event EventHandler<FavoritesChangedEventArgs> Favorites_Changed;
-
-        event EventHandler<FavoritesChangedEventArgs> Recents_Changed;
-
+        
         void AddFavorite(FavoriteRouteAndStop favorite, FavoriteType type);
 
         List<FavoriteRouteAndStop> GetFavorites(FavoriteType type);

--- a/OneBusAway.WP7.ViewModel/LocationTracker.cs
+++ b/OneBusAway.WP7.ViewModel/LocationTracker.cs
@@ -97,9 +97,6 @@ namespace OneBusAway.WP7.ViewModel
         private Object methodsRequiringLocationLock;
         private List<RequiresKnownLocation> methodsRequiringLocation;
         private AsyncOperationTracker operationTracker;
-#if DEBUG
-        private Timer timer = null;
-#endif
 
         #endregion
 

--- a/OneBusAway.WP7.ViewModel/MainPageVM.cs
+++ b/OneBusAway.WP7.ViewModel/MainPageVM.cs
@@ -213,7 +213,6 @@ namespace OneBusAway.WP7.ViewModel
             this.busServiceModel.StopsForRoute_Completed += new EventHandler<EventArgs.StopsForRouteEventArgs>(busServiceModel_StopsForRoute_Completed);
             
             this.appDataModel.Favorites_Changed += new EventHandler<EventArgs.FavoritesChangedEventArgs>(appDataModel_Favorites_Changed);
-            this.appDataModel.Recents_Changed += new EventHandler<EventArgs.FavoritesChangedEventArgs>(appDataModel_Recents_Changed);
 
             this.locationModel.LocationForAddress_Completed += busServiceModel_LocationForAddress_Completed;
         }
@@ -226,7 +225,6 @@ namespace OneBusAway.WP7.ViewModel
             this.busServiceModel.StopsForRoute_Completed -= new EventHandler<EventArgs.StopsForRouteEventArgs>(busServiceModel_StopsForRoute_Completed);
 
             this.appDataModel.Favorites_Changed -= new EventHandler<EventArgs.FavoritesChangedEventArgs>(appDataModel_Favorites_Changed);
-            this.appDataModel.Recents_Changed -= new EventHandler<EventArgs.FavoritesChangedEventArgs>(appDataModel_Recents_Changed);
 
             this.locationModel.LocationForAddress_Completed -= busServiceModel_LocationForAddress_Completed;
 
@@ -476,23 +474,6 @@ namespace OneBusAway.WP7.ViewModel
 
             UIAction(() => Favorites.Clear());
             e.newFavorites.ForEach(favorite => UIAction(() => Favorites.Add(favorite)));
-        }
-            else
-            {
-                ErrorOccured(this, e.error);
-            }
-        }
-
-        void appDataModel_Recents_Changed(object sender, EventArgs.FavoritesChangedEventArgs e)
-        {
-            Debug.Assert(e.error == null);
-
-            if (e.error == null)
-            {
-            e.newFavorites.Sort(new RecentLastAccessComparer());
-
-            UIAction(() => Recents.Clear());
-            e.newFavorites.ForEach(recent => UIAction(() => Recents.Add(recent)));
         }
             else
             {

--- a/OneBusAway.WP7.ViewModel/RouteDetailsVM.cs
+++ b/OneBusAway.WP7.ViewModel/RouteDetailsVM.cs
@@ -37,7 +37,6 @@ namespace OneBusAway.WP7.ViewModel
         private List<ArrivalAndDeparture> unfilteredArrivals;
         private Object arrivalsLock;
         private TripService tripService;
-        private bool resultsLoaded;
 
         #endregion
 
@@ -67,7 +66,6 @@ namespace OneBusAway.WP7.ViewModel
             routeFilter = null;
             arrivalsLock = new Object();
             tripService = TripServiceFactory.Singleton.TripService;
-            resultsLoaded = false;
         }
 
         #endregion
@@ -75,23 +73,7 @@ namespace OneBusAway.WP7.ViewModel
         #region Public Properties
 
         public ObservableCollection<ArrivalAndDeparture> ArrivalsForStop { get; private set; }
-
-        private bool noResultsAvailable;
-        public bool NoResultsAvailable
-        {
-            get
-            {
-                if (operationTracker.Loading == true || resultsLoaded == false)
-                {
-                    return false;
-                }
-                else
-                {
-                    return ArrivalsForStop.Count == 0;
-                }
-            }
-        }
- 
+         
         #endregion
 
         #region Public Methods
@@ -139,9 +121,6 @@ namespace OneBusAway.WP7.ViewModel
 
             this.routeFilter = routeFilter;
             RefreshArrivalsForStop(stop);
-
-            // We've sent our first call off, set resultsLoaded to true
-            resultsLoaded = true;
         }
 
         public void RefreshArrivalsForStop(Stop stop)
@@ -369,9 +348,6 @@ namespace OneBusAway.WP7.ViewModel
             this.busServiceModel.ArrivalsForStop_Completed -= new EventHandler<EventArgs.ArrivalsForStopEventArgs>(busServiceModel_ArrivalsForStop_Completed);
 
             this.operationTracker.ClearOperations();
-
-            // Reset resultsLoaded to false when they navigate away from the page
-            resultsLoaded = false;
         }
     }
 

--- a/OneBusAway.WP7.ViewModel/RouteDetailsVM.cs
+++ b/OneBusAway.WP7.ViewModel/RouteDetailsVM.cs
@@ -149,7 +149,7 @@ namespace OneBusAway.WP7.ViewModel
             if (stop != null)
             {
                 operationTracker.WaitForOperation("ArrivalsForStop", string.Empty);
-                busServiceModel.ArrivalsForStop(LocationTracker.CurrentLocation, stop);
+                busServiceModel.ArrivalsForStop(LocationTracker.CurrentLocationSafe, stop);
             }
         }
 

--- a/OneBusAway/AboutPage.xaml.cs
+++ b/OneBusAway/AboutPage.xaml.cs
@@ -69,14 +69,14 @@ namespace OneBusAway.WP7.View
         private void AddressBlock_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
             WebBrowserTask webBrowserTask = new WebBrowserTask();
-            webBrowserTask.URL = "http://onebusaway.org";
+            webBrowserTask.Uri = new Uri("http://onebusaway.org");
             webBrowserTask.Show();
         }
 
         private void TextBlock_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
             WebBrowserTask webBrowserTask = new WebBrowserTask();
-            webBrowserTask.URL = "http://onebusawaywp7.codeplex.com";
+            webBrowserTask.Uri = new Uri("http://onebusawaywp7.codeplex.com");
             webBrowserTask.Show();
         }
     }


### PR DESCRIPTION
This change avoids an annoying error in which the user would get the error message "The location is currently unavailable: Initializing" when trying to view current arrival times for a stop and the location has not loaded yet. This scenario is very common when the default pane is set to "Favorites" and the user wants to see the real-time arrival state of buses at their favorite stops.

As a side effect of this, when viewing a stop and the location has not yet loaded, the map will not zoom into the user's location until location is loaded, but real-time arrival information will load without needing the current location. This is contrasted with an error message that kicks the user back to the home screen.
